### PR TITLE
Updated healthcheck to use cookies with cURL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG DEBIAN_FRONTEND="noninteractive"
 
 ENV APP="Jackett"
 EXPOSE 9117
-HEALTHCHECK --interval=60s CMD curl -fsSL http://localhost:9117 || exit 1
+HEALTHCHECK --interval=60s CMD curl -fsSL -c /tmp/cookie -b /tmp/cookie http://localhost:9117 || exit 1
 
 # install app
 # https://github.com/Jackett/Jackett/releases

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG DEBIAN_FRONTEND="noninteractive"
 
 ENV APP="Jackett"
 EXPOSE 9117
-HEALTHCHECK --interval=60s CMD curl -fsSL -c /tmp/cookie -b /tmp/cookie http://localhost:9117 || exit 1
+HEALTHCHECK --interval=60s CMD curl -fsSL -b /tmp/cookie.txt http://localhost:9117 || exit 1
 
 # install app
 # https://github.com/Jackett/Jackett/releases


### PR DESCRIPTION
Using Jackett behind a revese proxy like Traefik gave curl redirect fails (50). Adding cookie store and read flags allows the healthcheck to reach the service.